### PR TITLE
Add functionality that allows users to select how many comments they want displayed

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>29.0-jre</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -23,13 +23,11 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
   /**

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -38,11 +38,11 @@ public class DataServlet extends HttpServlet {
   private static final int DEFAULT_MAX_COMMENTS = 20;
 
   /**
-   * Write to /data the messages ArrayList as a json string.
+   * Get comments from Datastore and add them to an ArrayList. Convert
+   * the ararylist to a json format and return it.
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // Get comments data from Datastore
     Query query = new Query(COMMENT_KIND).addSort(COMMENT_TIMESTAMP, SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
@@ -52,7 +52,6 @@ public class DataServlet extends HttpServlet {
       maxComments = Integer.parseInt(request.getParameter("max-comments"));
     }
 
-    // Add the comments obtained from Datastore to the comments Arraylist
     ArrayList<String> comments = new ArrayList<>();
     int counter = 0;
     for (Entity entity : results.asIterable()) {
@@ -64,10 +63,8 @@ public class DataServlet extends HttpServlet {
       }
     }
 
-    // Convert comments to json format and return them.
-    Gson gson = new Gson();
     response.setContentType(CONTENT_TYPE);
-    response.getWriter().println(gson.toJson(comments));
+    response.getWriter().println(convertMessageToJson(comments));
   }
 
   /**

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -46,7 +46,8 @@ public class DataServlet extends HttpServlet {
     Query query = new Query(COMMENT_KIND).addSort(COMMENT_TIMESTAMP, SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
-    int maxComments = Integer.parseInt(getParameter(request, "max-comments").orElse(DEFAULT_MAX_COMMENTS));
+    int maxComments =
+        Integer.parseInt(getParameter(request, "max-comments").orElse(DEFAULT_MAX_COMMENTS));
 
     ArrayList<String> comments = new ArrayList<>();
     int counter = 0;

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -20,6 +20,7 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -50,14 +51,9 @@ public class DataServlet extends HttpServlet {
         Integer.parseInt(getParameter(request, "max-comments").orElse(DEFAULT_MAX_COMMENTS));
 
     ArrayList<String> comments = new ArrayList<>();
-    int counter = 0;
-    for (Entity entity : results.asIterable()) {
+    for (Entity entity : Iterables.limit(results.asIterable(), maxComments)) {
       String comment = (String) entity.getProperty(COMMENT_VALUE);
       comments.add(comment);
-      counter++;
-      if (counter == maxComments) {
-        break;
-      }
     }
 
     response.setContentType(CONTENT_TYPE);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -35,7 +35,7 @@ public class DataServlet extends HttpServlet {
   private static final String COMMENT_VALUE = "text";
   private static final String COMMENT_TIMESTAMP = "timestamp";
   private static final String CONTENT_TYPE = "text/html;";
-  private static final int DEFAULT_MAX_COMMENTS = 20;
+  private static final String DEFAULT_MAX_COMMENTS = "20";
 
   /**
    * Get comments from Datastore and add them to an ArrayList. Convert
@@ -46,11 +46,7 @@ public class DataServlet extends HttpServlet {
     Query query = new Query(COMMENT_KIND).addSort(COMMENT_TIMESTAMP, SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
-    int maxComments = DEFAULT_MAX_COMMENTS;
-
-    if (request.getParameter("max-comments") != null) {
-      maxComments = Integer.parseInt(request.getParameter("max-comments"));
-    }
+    int maxComments = Integer.parseInt(getParameter(request, "max-comments").orElse(DEFAULT_MAX_COMMENTS));
 
     ArrayList<String> comments = new ArrayList<>();
     int counter = 0;

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -42,11 +42,22 @@ public class DataServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
+    int maxComments = 20;
+
+    if (request.getParameter("max-comments") != null) {
+      maxComments = Integer.parseInt(request.getParameter("max-comments"));
+    }
+
     // Add the comments obtained from Datastore to the comments Arraylist
     ArrayList<String> comments = new ArrayList<>();
+    int counter = 0;
     for (Entity entity : results.asIterable()) {
       String comment = (String) entity.getProperty("text");
       comments.add(comment);
+      counter++;
+      if (counter == maxComments) {
+        break;
+      }
     }
 
     Gson gson = new Gson();

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -288,6 +288,14 @@
           <textarea type="text" name="text-input" rows="6" class="form-control md-textarea"></textarea>
           <button id="comment-button" type="submit" class="btn btn-secondary btn-sm">Comment</button>
         </form>
+        <div class="btn-toolbar">
+          <div class="btn-group mr-2 ml-auto">
+            <button type="button" class="btn btn-secondary">5</button>
+            <button type="button" class="btn btn-secondary">10</button>
+            <button type="button" class="btn btn-secondary">15</button>
+            <button type="button" class="btn btn-secondary">20</button>
+          </div>
+        </div>
         <ul id="comments" class="list-group"></ul>
       </div>
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="style.css" />
     <script src="script.js"></script>
   </head>
-  <body onload="getMessage()">
+  <body onload="getComments()">
     <h1 id="name-text">ANUDEEP YAKKALA</h1>
 
     <!-- Random Quote -->
@@ -288,13 +288,13 @@
           <textarea type="text" name="text-input" rows="6" class="form-control md-textarea"></textarea>
           <button id="comment-button" type="submit" class="btn btn-secondary btn-sm">Comment</button>
         </form>
-        <div class="btn-toolbar">
-          <div class="btn-group mr-2 ml-auto">
-            <button type="button" class="btn btn-secondary">5</button>
-            <button type="button" class="btn btn-secondary">10</button>
-            <button type="button" class="btn btn-secondary">15</button>
-            <button type="button" class="btn btn-secondary">20</button>
-          </div>
+        <div id="num-comments-container">
+          <select id="num-comments-selector" onchange="getComments()">
+            <option value="5">5 Comments</option>
+            <option value="10" selected="selected">10 Comments</option>
+            <option value="15">15 Comments</option>
+            <option value="20">20 Comments</option>
+          </select>
         </div>
         <ul id="comments" class="list-group"></ul>
       </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -291,7 +291,7 @@
         <div id="num-comments-container">
           <select id="num-comments-selector" onchange="getComments()">
             <option value="5">5 Comments</option>
-            <option value="10" selected="selected">10 Comments</option>
+            <option value="10">10 Comments</option>
             <option value="15">15 Comments</option>
             <option value="20">20 Comments</option>
           </select>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -82,7 +82,6 @@ function contactEmail() {  // eslint-disable-line no-unused-vars
   window.location.href = 'index.html';
 }
 
-/* eslint-enable no-undef */
 /* eslint-enable no-unused-vars */
 
 function cancelRedirect() {  // eslint-disable-line no-unused-vars
@@ -94,7 +93,7 @@ function cancelRedirect() {  // eslint-disable-line no-unused-vars
  * section on the home page.
  */
 function getComments() {  // eslint-disable-line no-unused-vars
-  const numComments = $("#num-comments-selector :selected").val();
+  const numComments = $('#num-comments-selector :selected').val();
   fetch('/data?max-comments=' + numComments)
       .then((response) => response.json())
       .then((messages) => {
@@ -105,6 +104,8 @@ function getComments() {  // eslint-disable-line no-unused-vars
         });
       });
 }
+
+/* eslint-enable no-undef */
 
 function createListElement(text) {
   const liElement = document.createElement('li');

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -94,13 +94,15 @@ function cancelRedirect() {  // eslint-disable-line no-unused-vars
  * section on the home page.
  */
 function getMessage() {  // eslint-disable-line no-unused-vars
-  fetch('/data').then((response) => response.json()).then((messages) => {
-    const commentsElement = document.getElementById('comments');
-    commentsElement.innerHTML = '';
-    messages.forEach((message) => {
-      commentsElement.appendChild(createListElement(message));
-    });
-  });
+  fetch('/data?max-comments=10')
+      .then((response) => response.json())
+      .then((messages) => {
+        const commentsElement = document.getElementById('comments');
+        commentsElement.innerHTML = '';
+        messages.forEach((message) => {
+          commentsElement.appendChild(createListElement(message));
+        });
+      });
 }
 
 function createListElement(text) {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -93,8 +93,9 @@ function cancelRedirect() {  // eslint-disable-line no-unused-vars
  * Obtains the stored comments and adds them to the comment
  * section on the home page.
  */
-function getMessage() {  // eslint-disable-line no-unused-vars
-  fetch('/data?max-comments=10')
+function getComments() {  // eslint-disable-line no-unused-vars
+  const numComments = $("#num-comments-selector :selected").val();
+  fetch('/data?max-comments=' + numComments)
       .then((response) => response.json())
       .then((messages) => {
         const commentsElement = document.getElementById('comments');

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -213,4 +213,16 @@ a:hover {
   margin-top: 10px;
 }
 
+#num-comments-container {
+  text-align: right;
+}
+
+#num-comments-selector {
+  background-color: #6c757d;
+  border-radius: 5px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 400;
+}
+
 /* comments end */


### PR DESCRIPTION
Added  a selection that allows users choose if they want up to 5, 10, 15, or 20 comments displayed on the page. Also made it so that the comments are refreshed when a user chooses a selection so that the page can be updated appropriately. 

Modified the doGet() function so that it accepts a query string containing the number of comments to return. This determines the number of saved comments that are returned. 

Modified the getComments() function to add a query string to the GET request based on the user selection on the front end. The default selection is 5 comments. 

The following is a gif showing the new feature:
![capture](https://user-images.githubusercontent.com/43008373/83692264-856fb200-a5a8-11ea-94c6-1fd82efd3f88.gif)

Screenshot with the drop-down because it doesn't get shown in the video:
![image](https://user-images.githubusercontent.com/43008373/83692089-2e69dd00-a5a8-11ea-9384-db83d9ef1d38.png)

