### PR TITLE
Add option to clear all comments. 

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -108,3 +108,23 @@ public class DataServlet extends HttpServlet {
     return value;
   }
 }
+
+@WebServlet("/delete-data")
+public class DataServlet extends HttpServlet {
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Get comments data from Datastore
+    Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(query);
+
+    // Delete all the comments in DataStore
+    for (Entity entity : results.asIterable()) {
+      datastore.delete(entity.getKey());
+    }
+
+    // Convert comments to json format and return them
+    response.setContentType("text/html;");
+    response.getWriter().println();
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -108,23 +108,3 @@ public class DataServlet extends HttpServlet {
     return value;
   }
 }
-
-@WebServlet("/delete-data")
-public class DataServlet extends HttpServlet {
-  @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // Get comments data from Datastore
-    Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    PreparedQuery results = datastore.prepare(query);
-
-    // Delete all the comments in DataStore
-    for (Entity entity : results.asIterable()) {
-      datastore.delete(entity.getKey());
-    }
-
-    // Convert comments to json format and return them
-    response.setContentType("text/html;");
-    response.getWriter().println();
-  }
-}

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServerlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServerlet.java
@@ -11,21 +11,22 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/**
+  * Get comments data from Datastore. Delete all of the comments obtained
+  * from Datastore. Then, return an empty reponse. 
+  */
 @WebServlet("/delete-comments")
 public class DeleteServerlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // Get comments data from Datastore
     Query query = new Query("Comment");
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
-    // Delete all the comments in DataStore
     for (Entity entity : results.asIterable()) {
       datastore.delete(entity.getKey());
     }
 
-    // Return an empty response
     response.setContentType("text/html;");
     response.getWriter().println();
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServerlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServerlet.java
@@ -17,9 +17,11 @@ import javax.servlet.http.HttpServletResponse;
  */
 @WebServlet("/delete-comments")
 public class DeleteServerlet extends HttpServlet {
+  private static final String COMMENT_KIND = "Comment";
+
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    Query query = new Query("Comment");
+    Query query = new Query(COMMENT_KIND);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServerlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServerlet.java
@@ -12,9 +12,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
-  * Get comments data from Datastore. Delete all of the comments obtained
-  * from Datastore. Then, return an empty reponse. 
-  */
+ * Get comments data from Datastore. Delete all of the comments obtained
+ * from Datastore. Then, return an empty reponse.
+ */
 @WebServlet("/delete-comments")
 public class DeleteServerlet extends HttpServlet {
   @Override

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServerlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServerlet.java
@@ -1,0 +1,32 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/delete-comments")
+public class DeleteServerlet extends HttpServlet {
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Get comments data from Datastore
+    Query query = new Query("Comment");
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(query);
+
+    // Delete all the comments in DataStore
+    for (Entity entity : results.asIterable()) {
+      datastore.delete(entity.getKey());
+    }
+
+    // Return an empty response
+    response.setContentType("text/html;");
+    response.getWriter().println();
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
@@ -1,0 +1,35 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Get comments data from Datastore. Delete all of the comments obtained
+ * from Datastore. Then, return an empty reponse.
+ */
+@WebServlet("/delete-comments")
+public class DeleteServlet extends HttpServlet {
+  private static final String COMMENT_KIND = "Comment";
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Query query = new Query(COMMENT_KIND);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(query);
+
+    for (Entity entity : results.asIterable()) {
+      datastore.delete(entity.getKey());
+    }
+
+    response.setContentType("text/html;");
+    response.getWriter().println();
+  }
+}

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -297,6 +297,7 @@
           </select>
         </div>
         <ul id="comments" class="list-group"></ul>
+        <button type="submit" class="btn btn-secondary btn-sm" onclick="deleteComments()">Clear</button>
       </div>
     </div>
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -105,6 +105,16 @@ function getComments() {  // eslint-disable-line no-unused-vars
       });
 }
 
+/**
+ * Delete all the comments stored server-side and update the home page
+ * to reflect these changes.
+ */
+function deleteComments() {  // eslint-disable-line no-unused-vars
+  fetch('/delete-comments', {method: 'POST'}).then(() => {
+    getComments();
+  });
+}
+
 /* eslint-enable no-undef */
 
 function createListElement(text) {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -110,9 +110,7 @@ function getComments() {  // eslint-disable-line no-unused-vars
  * to reflect these changes.
  */
 function deleteComments() {  // eslint-disable-line no-unused-vars
-  fetch('/delete-comments', {method: 'POST'}).then(() => {
-    getComments();
-  });
+  fetch('/delete-comments', {method: 'POST'}).then(() => void getComments());
 }
 
 /* eslint-enable no-undef */


### PR DESCRIPTION
Added a new function that handles a POST request to"/delete-comments". All the comments are found and removed from Datastore. 

Added a JavaScript function that sends a POST request to "/delete-comments" and calls getComments() afterwards to update the comments displayed on the home page. 

Added a clear button underneath the comments section that calls the deleteComments() function. 

The following is s gif of the new feature:
![capture](https://user-images.githubusercontent.com/43008373/83916568-44071000-a72a-11ea-8152-d10f1dcbd95d.gif)
