### PR TITLE
Display the email address of the user who commented above the comment. 

### DIFF
--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -112,7 +112,8 @@ function getComments() {  // eslint-disable-line no-unused-vars
         const commentsElement = document.getElementById('comments');
         commentsElement.innerHTML = '';
         messages.forEach((message) => {
-          commentsElement.appendChild(createListElement(message));
+          commentsElement.appendChild(
+              createListElement(message.email + '\n' + message.text));
         });
       });
 }


### PR DESCRIPTION
Modified the doGet() function to return a comment object instead of a string so that both the email and the comment message can be returned. 

The email address of the user who commented is displayed above the user's comment. 

The following is a screenshot showing the changes:
![image](https://user-images.githubusercontent.com/43008373/84215936-d38b2680-aa7c-11ea-9c15-fb4108db8a7b.png)
