### PR TITLE
Modify query() function to work with optional attendees. 

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -31,10 +31,10 @@ public final class FindMeetingQuery {
           events, request.getAttendees(), request.getOptionalAttendees());
       Collections.sort(requestAttendeeRanges, TimeRange.ORDER_BY_START);
       requestAttendeeRanges = combineOverlaps(requestAttendeeRanges);
-      List<TimeRange> noConflicts =
+      List<TimeRange> results =
           findMeetingRangesWithNoConflict(requestAttendeeRanges, request.getDuration());
-      if (!noConflicts.isEmpty()) {
-        return noConflicts;
+      if (!results.isEmpty()) {
+        return results;
       } else if (request.getAttendees().isEmpty()) {
         return Collections.emptyList();
       }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -31,10 +31,10 @@ public final class FindMeetingQuery {
           events, request.getAttendees(), request.getOptionalAttendees());
       Collections.sort(requestAttendeeRanges, TimeRange.ORDER_BY_START);
       requestAttendeeRanges = combineOverlaps(requestAttendeeRanges);
-      List<TimeRange> results =
+      List<TimeRange> result =
           findMeetingRangesWithNoConflict(requestAttendeeRanges, request.getDuration());
-      if (!results.isEmpty()) {
-        return results;
+      if (!result.isEmpty()) {
+        return result;
       } else if (request.getAttendees().isEmpty()) {
         return Collections.emptyList();
       }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -27,8 +27,8 @@ public final class FindMeetingQuery {
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     if (!request.getOptionalAttendees().isEmpty()) {
-      List<TimeRange> requestAttendeeRanges =
-          filterRequestAttendeeTimeRangesOptional(events, request.getAttendees(), request.getOptionalAttendees());
+      List<TimeRange> requestAttendeeRanges = filterToRequestAttendeeTimeRangesOptional(
+          events, request.getAttendees(), request.getOptionalAttendees());
       Collections.sort(requestAttendeeRanges, TimeRange.ORDER_BY_START);
       requestAttendeeRanges = combineOverlaps(requestAttendeeRanges);
       List<TimeRange> noConflicts =
@@ -40,7 +40,7 @@ public final class FindMeetingQuery {
       }
     }
     List<TimeRange> requestAttendeeRanges =
-        filterRequestAttendeeTimeRanges(events, request.getAttendees());
+        filterToRequestAttendeeTimeRanges(events, request.getAttendees());
     Collections.sort(requestAttendeeRanges, TimeRange.ORDER_BY_START);
     requestAttendeeRanges = combineOverlaps(requestAttendeeRanges);
     return findMeetingRangesWithNoConflict(requestAttendeeRanges, request.getDuration());
@@ -61,16 +61,14 @@ public final class FindMeetingQuery {
    * Returns a List of all the events with at least one attendee or one optional
    * attendee from the request.
    */
-  private ArrayList<TimeRange> filterRequestAttendeeTimeRangesOptional(Collection<Event> events,
+  private List<TimeRange> filterToRequestAttendeeTimeRangesOptional(Collection<Event> events,
       Collection<String> requestAttendees, Collection<String> optionalRequestAttendees) {
-    ArrayList<TimeRange> requestAttendeeRanges = new ArrayList<>();
-    for (Event event : events) {
-      if ((!Collections.disjoint(event.getAttendees(), requestAttendees))
-          || (!Collections.disjoint(event.getAttendees(), optionalRequestAttendees))) {
-        requestAttendeeRanges.add(event.getWhen());
-      }
-    }
-    return requestAttendeeRanges;
+    return events.stream()
+        .filter(event
+            -> (!Collections.disjoint(event.getAttendees(), requestAttendees)
+                || !Collections.disjoint(event.getAttendees(), optionalRequestAttendees)))
+        .map(event -> event.getWhen())
+        .collect(Collectors.toList());
   }
 
   /*

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -27,18 +27,22 @@ public final class FindMeetingQuery {
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     if (!request.getOptionalAttendees().isEmpty()) {
-      List<TimeRange> requestAttendeeRanges = filterToRequestAttendeeTimeRangesOptional(
+      List<TimeRange> requestAttendeeRangesWithOptional = filterToRequestAttendeeTimeRangesOptional(
           events, request.getAttendees(), request.getOptionalAttendees());
-      Collections.sort(requestAttendeeRanges, TimeRange.ORDER_BY_START);
-      requestAttendeeRanges = combineOverlaps(requestAttendeeRanges);
+      Collections.sort(requestAttendeeRangesWithOptional, TimeRange.ORDER_BY_START);
+      requestAttendeeRangesWithOptional = combineOverlaps(requestAttendeeRangesWithOptional);
       List<TimeRange> result =
-          findMeetingRangesWithNoConflict(requestAttendeeRanges, request.getDuration());
+          findMeetingRangesWithNoConflict(requestAttendeeRangesWithOptional, request.getDuration());
       if (!result.isEmpty()) {
         return result;
       } else if (request.getAttendees().isEmpty()) {
+        // If there are no mandotory attendees and no non-conflicting times for optional
+        // attendees, return an empty list.
         return Collections.emptyList();
       }
     }
+    // If there are no times where all the optional and mandotory attendees can attend,
+    // check for times where all the mandotory attendees can attend.
     List<TimeRange> requestAttendeeRanges =
         filterToRequestAttendeeTimeRanges(events, request.getAttendees());
     Collections.sort(requestAttendeeRanges, TimeRange.ORDER_BY_START);


### PR DESCRIPTION
If there are optional attendees provided in the request, the algorithm finds all the time ranges long enough for the request that all the mandatory and optional attendees can attend. If there is at least one time range in the collection of found time ranges, it is returned. Otherwise, the optional attendees are ignored. 

The modified algorithm passes the 5 new test cases as well as the 21 original test cases:
![image](https://user-images.githubusercontent.com/43008373/84711837-11c09400-af1c-11ea-9f21-b3e9351d8e72.png)
